### PR TITLE
Reuse shader instances that are still valid

### DIFF
--- a/src/hook/game_functions.json
+++ b/src/hook/game_functions.json
@@ -10,6 +10,7 @@
     "memory_map_initialize": {"address": "0x445230", "replace": true},
     "game_state_table_new": {"address": "0x53b3b0", "replace": true, "use_return_value": true, "arguments": ["0", "4", "ebx"]},
     "table_new": {"address": "0x4d3770", "replace": true, "use_return_value": true, "arguments": ["0", "4", "ebx"]},
+    "table_remove_element": {"address": "0x4d3910", "replace": false, "arguments": ["eax", "edx"]},
     "crc32_calculate": {"address": "0x4d36d0", "replace": false, "arguments": ["0", "4", "8"]},
     "players_data_initialize": {"address": "0x476170", "replace": true},
 

--- a/src/impl/memory/table.h
+++ b/src/impl/memory/table.h
@@ -161,6 +161,13 @@ void table_init_element(void *table, void *new_element_location);
 void *table_add_element(void *table);
 
 /**
+ * Remove an element from a table by it's handle.
+ * @param table table pointer
+ * @param handle Handle of the element
+ */
+void table_remove_element(void *table, TableResourceHandle handle);
+
+/**
  * Clear the contents of a table.
  * @param table table pointer
  */

--- a/src/impl/rasterizer/rasterizer_shader_transparent_generic.h
+++ b/src/impl/rasterizer/rasterizer_shader_transparent_generic.h
@@ -25,8 +25,9 @@ typedef struct ShaderTransparentGenericInstance {
     char hash[32];
     void *compiled_shader;
     IDirect3DPixelShader9 *shader;
+    Bool invalid;
 } ShaderTransparentGenericInstance;
-_Static_assert(sizeof(ShaderTransparentGenericInstance) == 48);
+_Static_assert(sizeof(ShaderTransparentGenericInstance) == 52);
 
 MAKE_TABLE_STRUCT(ShaderTransparentGenericInstances, ShaderTransparentGenericInstance);
 
@@ -56,6 +57,12 @@ void rasterizer_dx9_transparent_generic_preprocess(TransparentGeometryGroup *gro
  * Create an instance of the shader transparent generic for each tag in the current map.
  */
 void rasterizer_shader_transparent_generic_create_instances_for_current_map(void);
+
+/**
+ * Create an instance of the shader transparent generic for each tag in the current map except try to reuse 
+ * instaces from the previous map that are still valid to save shader compilation time. 
+ */
+void rasterizer_shader_transparent_generic_update_instances_for_current_map(void);
 
 /**
  * Clear all shader transparent generic instances.


### PR DESCRIPTION
Given most maps in the campaign share many shader_transparent_generic tags, might as well reuse shader instances if they are still valid instead of recompiling every shader on map load.

Needs to be run after map load. I've been running it with the chimera map load event which worked fine but probably needs a dedicated implementation in ringword.